### PR TITLE
fix: proxy http:// upstream requests too

### DIFF
--- a/app/stream/routes.py
+++ b/app/stream/routes.py
@@ -71,7 +71,7 @@ def generic_stream(stream_url):
     headers = filter_headers(request.headers.items())
     upstream_response = app.session.get(
         stream_url,
-        proxies={"https": app.EXTERNAL_PROXY},
+        proxies={"http": app.EXTERNAL_PROXY, "https": app.EXTERNAL_PROXY},
         headers=headers,
         allow_redirects=True,
         stream=True,


### PR DESCRIPTION
The proxies dict only set an https entry, so plain-http podcast enclosure URLs bypassed EXTERNAL_PROXY (gluetun) entirely and were fetched directly instead of through the VPN.